### PR TITLE
Remove a default `pr-comment` message from `communicate-on-pull-request-merged` Action

### DIFF
--- a/communicate-on-pull-request-merged/README.md
+++ b/communicate-on-pull-request-merged/README.md
@@ -11,6 +11,7 @@ steps:
 - uses: fastlane/github-action/communicate-on-pull-request-merged@latest
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
+    pr-comment: "Hey @${{ github.event.pull_request.user.login }} :wave: Thank you for your contribution!"
 ```
 
 # License

--- a/communicate-on-pull-request-merged/action.yml
+++ b/communicate-on-pull-request-merged/action.yml
@@ -7,11 +7,7 @@ inputs:
     required: true
   pr-comment:
     description: 'A comment to post on a pull request when code changes are merged'
-    default: "Thank you for your contribution to _fastlane_ and congrats on getting this pull request merged :tada:\n
-              The code change now lives in the `master` branch, however it wasn't released to [RubyGems](https://rubygems.org/gems/fastlane) yet.\n
-              We usually ship about once a week, and your PR will be included in the next one.\n\n
-              Please let us know if this change requires an immediate release by adding a comment here :+1:\n
-              We'll notify you once we shipped a new release with your changes :rocket:"
+    required: true
   pr-label:
     description: 'The label to apply when a pull request is merged'
     default: 'status: included-in-next-release'

--- a/communicate-on-pull-request-merged/lib/main.js
+++ b/communicate-on-pull-request-merged/lib/main.js
@@ -38,7 +38,7 @@ function run() {
                 return;
             }
             yield addLabels(client, prNumber, [core.getInput('pr-label')]);
-            yield addComment(client, prNumber, core.getInput('pr-comment'));
+            yield addComment(client, prNumber, core.getInput('pr-comment', { required: true }));
         }
         catch (error) {
             core.setFailed(error.message);

--- a/communicate-on-pull-request-merged/src/main.ts
+++ b/communicate-on-pull-request-merged/src/main.ts
@@ -27,7 +27,11 @@ export async function run() {
     }
 
     await addLabels(client, prNumber, [core.getInput('pr-label')]);
-    await addComment(client, prNumber, core.getInput('pr-comment'));
+    await addComment(
+      client,
+      prNumber,
+      core.getInput('pr-comment', {required: true})
+    );
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
### Description

The default message does not contain greetings for a pull request's author. 

```
Hey @mollyIV :wave: // 👈default message does not contain this

Thank you for your contribution...
```

To avoid ambiguity, this PR is making the `pr-comment` parameter required. 

The example usage in a workflow file:

```yaml
- uses: fastlane/github-actions/communicate-on-pull-request-merged@latest
      with:
        repo-token: "${{ secrets.BOT_TOKEN }}"
        pr-comment: "Hey @${{ github.event.pull_request.user.login }} :wave:\nThank you for your contribution to _fastlane_ and congrats on..."
```

closes https://github.com/fastlane/github-actions/issues/21