### PR TITLE
It is possible to remove a label from a pull request via `communicate-on-pull-request-merged` GitHub Action

### DIFF
--- a/communicate-on-pull-request-merged/__tests__/main.test.ts
+++ b/communicate-on-pull-request-merged/__tests__/main.test.ts
@@ -24,7 +24,8 @@ describe('action test suite', () => {
     it(`It posts a comment on a merged issue for (${scenario.response})`, async () => {
       process.env['INPUT_REPO-TOKEN'] = 'token';
       process.env['INPUT_PR-COMMENT'] = 'message';
-      process.env['INPUT_PR-LABEL'] = 'label';
+      process.env['INPUT_PR-LABEL-TO-ADD'] = 'label-to-add';
+      process.env['INPUT_PR-LABEL-TO-REMOVE'] = 'label-to-remove';
 
       process.env['GITHUB_REPOSITORY'] = 'foo/bar';
       process.env['GITHUB_EVENT_PATH'] = path.join(
@@ -39,7 +40,9 @@ describe('action test suite', () => {
           '{"body":"message","event":"COMMENT"}'
         )
         .reply(200)
-        .post('/repos/foo/bar/issues/10/labels', '{"labels":["label"]}')
+        .get('/repos/foo/bar/issues/10/labels')
+        .reply(200, JSON.parse('[]'))
+        .post('/repos/foo/bar/issues/10/labels', '{"labels":["label-to-add"]}')
         .reply(200);
 
       const main = require('../src/main');
@@ -53,7 +56,8 @@ describe('action test suite', () => {
     it(`It does not post a comment on a closed pull request for (${scenario.response})`, async () => {
       process.env['INPUT_REPO-TOKEN'] = 'token';
       process.env['INPUT_PR-COMMENT'] = 'message';
-      process.env['INPUT_PR-LABEL'] = 'label';
+      process.env['INPUT_PR-LABEL-TO-ADD'] = 'label-to-add';
+      process.env['INPUT_PR-LABEL-TO-REMOVE'] = 'label-to-remove';
 
       process.env['GITHUB_REPOSITORY'] = 'foo/bar';
       process.env['GITHUB_EVENT_PATH'] = path.join(
@@ -68,7 +72,9 @@ describe('action test suite', () => {
           '{"body":"message","event":"COMMENT"}'
         )
         .reply(200)
-        .post('/repos/foo/bar/issues/10/labels', '{"labels":["label"]}')
+        .get('/repos/foo/bar/issues/10/labels')
+        .reply(200, JSON.parse('[]'))
+        .post('/repos/foo/bar/issues/10/labels', '{"labels":["label-to-add"]}')
         .reply(200);
 
       const main = require('../src/main');

--- a/communicate-on-pull-request-merged/action.yml
+++ b/communicate-on-pull-request-merged/action.yml
@@ -8,9 +8,12 @@ inputs:
   pr-comment:
     description: 'A comment to post on a pull request when code changes are merged'
     required: true
-  pr-label:
+  pr-label-to-add:
     description: 'The label to apply when a pull request is merged'
     default: 'status: included-in-next-release'
+  pr-label-to-remove:
+      description: 'The label to remove when a pull request is merged'
+      default: 'status: needs-attention'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
### Description 

The current bot 🤖on _fastlane_ repository [removes the `status: needs-attention` label](https://github.com/fastlane/issue-bot/blob/457348717d99e5ffde34ca1619e7253ed51ec172/bot.rb#L158-L159) from merged pull request:

```ruby
    def process_closed_pr(pr, prs_to_releases)
      remove_needs_attention_from(pr) if has_label?(pr, NEEDS_ATTENTION)
```

`communicate-on-pull-request-merged` GitHub Action should do the same and this PR is introducing this functionality. 

### Testing 

#### Manual testing

A workflow file used for a manual testing:

```yml
name: Processing pull requests
on: 
  pull_request:
    types: [closed]

jobs:   
  pr-release-lifecycle:
    name: PR release lifecycle
    runs-on: ubuntu-latest    
    steps:
      - name: Git checkout
        if: github.event.pull_request.merged
        uses: actions/checkout@master
        with:
          ref: refs/heads/master
      
      - name: Communicate on PR merged
        if: github.event.pull_request.merged
        uses: mollyIV/github-actions/communicate-on-pull-request-merged@remove-label-via-communicate-on-pr-merged
        with:
          repo-token: "${{ secrets.BOT_TOKEN }}"
          pr-comment: "Hello @${{ github.event.pull_request.user.login }} Thanks for your contribution!"
          pr-label-to-add: 'waiting-for-release'
          pr-label-to-remove: 'needs-attention'
```

<img width="1051" alt="Screen Shot 2019-12-14 at 20 53 02" src="https://user-images.githubusercontent.com/10795657/70853859-07add200-1eb4-11ea-8153-7c9353cc0639.png">

<img width="1078" alt="Screen Shot 2019-12-14 at 20 54 09" src="https://user-images.githubusercontent.com/10795657/70853861-10060d00-1eb4-11ea-8042-ab074c53e244.png">

My bot is set to my private account, that's why you see the comments from the author 😅 

I also tested the action when there's no label added to the PR

![image](https://user-images.githubusercontent.com/10795657/70853905-dc77b280-1eb4-11ea-8406-520984af5691.png)


🎊 🎊 