### PR TITLE
Fix incorrect example text in README's

### DIFF
--- a/communicate-on-pull-request-merged/README.md
+++ b/communicate-on-pull-request-merged/README.md
@@ -8,7 +8,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: fastlane/github-action/communicate-on-pull-request-merged@latest
+- uses: fastlane/github-actions/communicate-on-pull-request-merged@latest
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
     pr-comment: "Hey @${{ github.event.pull_request.user.login }} :wave: Thank you for your contribution!"

--- a/communicate-on-pull-request-released/README.md
+++ b/communicate-on-pull-request-released/README.md
@@ -8,7 +8,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: fastlane/github-action/communicate-on-pull-request-released@latest
+- uses: fastlane/github-actions/communicate-on-pull-request-released@latest
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/fastlane-env-reminder/README.md
+++ b/fastlane-env-reminder/README.md
@@ -8,7 +8,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: fastlane/github-action/fastlane-env-reminder@latest
+- uses: fastlane/github-actions/fastlane-env-reminder@latest
   with:
     repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
All the README's have broken examples resulting in broken actions, maybe the repo name was changed from:
 `fastlane/github-action` to `fastlane/github-actions`
![image](https://user-images.githubusercontent.com/11782590/79455528-2a035800-802c-11ea-9930-a45b2d00d180.png)
