### PR TITLE
build: only prevent compiled changes against master

### DIFF
--- a/.github/workflows/close.yml
+++ b/.github/workflows/close.yml
@@ -2,6 +2,8 @@ name: Close PR (if compiled file(s) are touched)
 
 on:
   pull_request_target:
+    branches:
+      - master
     types: [opened, reopened, synchronize]
     paths:
       - 'communicate-on-pull-request-merged/lib/**'


### PR DESCRIPTION
Since releases are squashed commits against "latest". This would improperly fire and block merge. We only want to block compiled changes into mainline.