### PR TITLE
fix: add run() for 'fastlane-env-reminder'

### DIFF
--- a/fastlane-env-reminder/package.json
+++ b/fastlane-env-reminder/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "An action for adding a comment to include `fastlane env` in an issue description",
   "scripts": {
-    "build": "ncc build src/main.ts --license licenses.txt -o lib",
+    "build": "ncc build src/index.ts --license licenses.txt -o lib",
     "format": "prettier --write **/*.ts",
     "test": "NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 jest"
   },

--- a/fastlane-env-reminder/src/index.ts
+++ b/fastlane-env-reminder/src/index.ts
@@ -1,0 +1,3 @@
+import {run} from './main.js';
+
+run();

--- a/fastlane-env-reminder/src/main.ts
+++ b/fastlane-env-reminder/src/main.ts
@@ -52,5 +52,3 @@ export async function run() {
     return;
   }
 }
-
-run();


### PR DESCRIPTION
These are async - so they need execution which I foolishly removed.