### PR TITLE
build: max concurrency of 1 in dist.yml

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Commit Dist
     strategy:
+      max-parallel: 1
       matrix:
         repo:
           - communicate-on-pull-request-merged


### PR DESCRIPTION
This will prevent collisions on all folders pushing dist changes at once.